### PR TITLE
chore : fix Dockerfile to use fully qualified image name

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -1,16 +1,16 @@
 # Build the manager binary
 # FROM registry.access.redhat.com/ubi8/go-toolset:1.17.7 as builder
-FROM golang:1.18 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9-1743094161 AS builder
 
 USER root
 WORKDIR /workspace
 COPY . .
 RUN make build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1742914212
 
-LABEL MAINTAINER "Adrian Riobo" "<ariobolo@redhat.com>"
+LABEL MAINTAINER="Adrian Riobo <ariobolo@redhat.com>"
 
 COPY --from=builder /workspace/out/eventmanager /workspace/images/builder/entrypoint.sh /usr/local/bin/
 
-ENTRYPOINT entrypoint.sh 
+ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
## Description

When I was trying to build container image using podman, I was getting this error:
```
podman build -t quay.io/devtools-qe-incubator/eventmanager:0.0.4 -f images/builder/Dockerfile .
[1/2] STEP 1/5: FROM golang:1.18 AS builder
Error: creating build container: short-name "golang:1.18" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
```

+ Update Dockerfile to use fully qualified base image name with registry prefix in order to be used by podman.
+ Update runner image to use Red Hat UBI9 image
+ Replace Entrypoint instruction to use exec form instead of shell form